### PR TITLE
PEM support for key pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "biscuit-auth"
-version = "6.0.0-beta.1"
+version = "6.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c201f713f0a77e455f9bfd74bc47a8c009d41abc6c755fd4d34d72ae593f6a7"
+checksum = "dccca0ba30ea46587848444dc87ea3f379cd34cccb4d59b35bb7f45e923e23d0"
 dependencies = [
  "base64",
  "biscuit-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 
 [dependencies]
 atty = "0.2.14"
-biscuit-auth = { version = "6.0.0-beta.1", features = ["serde-error"] }
+biscuit-auth = { version = "6.0.0-beta.2", features = ["serde-error", "pem"] }
 clap = { version = "^3.0", features = ["color", "derive"] }
 chrono = "^0.4"
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ $ biscuit keypair --only-private-key > private-key-file
 ### Generate a public key from a private key
 
 ```sh
-$ biscuit keypair --from-private-key-file private-key-file --only-public-key
+$ biscuit keypair --from-file private-key-file --only-public-key
 > ed25519/2341bc530d8f074100734a41cc05cc82e4e2564eff61b0408f8e37a08f384767
 ```
 
@@ -85,10 +85,10 @@ $ biscuit inspect biscuit-file
 > 🙈 Datalog check skipped 🛡️
 ```
 
-A public key can be provided to check the biscuit root key (the command exits with a success code only if the keys match)
+A public key can be provided to verify the biscuit signatures
 
 ```sh
-$ # this will make sure the biscuit root key is the same as the one that's provided
+$ # this will make sure the biscuit has been signed with the expected key pair
 $ biscuit inspect --public-key-file public-key-file biscuit-file
 > Authority block:
 > == Datalog v3.0 ==
@@ -103,7 +103,7 @@ $ biscuit inspect --public-key-file public-key-file biscuit-file
 > 🙈 Datalog check skipped 🛡️
 ```
 
-An authorizer can be provided to check if the biscuit would be allowed in a given context (the command exits with a success code only if the keys match and if the authorization suceeded).
+An authorizer can be provided to check if the biscuit would be allowed in a given context (the command exits with a success code only if the signatures are verified and if the authorization suceeded).
 
 If you want to use your text editor to type in the authorizer, you can use `--authorize-interactive` instead.
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 pub enum CliError {
     #[error("file not found: {0}")]
     FileNotFound(PathBuf),
+    #[error("error reading file: {0}")]
+    FileError(std::io::Error),
     #[error("I cannot read input from both stdin and an interactive editor. Please use proper files or flags instead.")]
     StdinEditorConflict,
     #[error("I cannot read several pieces of input from stdin at the same time. Please use proper files or flags instead.")]

--- a/src/input.rs
+++ b/src/input.rs
@@ -503,14 +503,7 @@ pub fn parse_param(kv: &str) -> Result<Param, std::io::Error> {
 
     match annotation {
       Some("pubkey") => {
-        let hex_key = value.strip_prefix("ed25519/").ok_or_else(|| Error::new(
-        ErrorKind::Other,
-        "Unsupported public key type. Only hex-encoded ed25519 public keys are supported. They must start with `ed25519/`.",
-        ))?;
-        let bytes =
-            hex::decode(hex_key).map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)));
-        let pubkey = PublicKey::from_bytes(&bytes?, Algorithm::Ed25519)
-            .map_err(|e| Error::new(ErrorKind::Other, format!("{}", &e)))?;
+        let pubkey = value.parse().map_err(Error::other)?;
         Ok(Param::PublicKey(name.to_string(), pubkey))
       },
       Some("integer") => {

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,21 +3,21 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-use anyhow::Result;
+use anyhow::{bail, Result};
 use atty::Stream;
 use biscuit_auth::{
     builder::{BiscuitBuilder, BlockBuilder, Rule, Term},
-    Algorithm, Authorizer, AuthorizerBuilder, PrivateKey, PublicKey, ThirdPartyRequest,
-    UnverifiedBiscuit,
+    Authorizer, AuthorizerBuilder, PrivateKey, PublicKey, ThirdPartyRequest, UnverifiedBiscuit,
 };
 use chrono::{DateTime, Duration, Utc};
+use clap::{PossibleValue, ValueEnum};
 use parse_duration as duration_parser;
-use std::env;
 use std::fs;
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::Command;
 use std::{collections::HashMap, convert::TryInto};
+use std::{env, fmt::Display};
 
 use crate::errors::CliError::*;
 
@@ -26,9 +26,42 @@ pub enum BiscuitFormat {
     Base64Biscuit,
 }
 
+#[derive(PartialEq, Clone, Copy, Debug, ValueEnum)]
 pub enum KeyFormat {
-    RawBytes,
-    HexKey,
+    Raw,
+    Hex,
+    Pem,
+}
+
+impl Default for KeyFormat {
+    fn default() -> Self {
+        Self::Hex
+    }
+}
+
+#[derive(PartialEq, Clone, Copy, Debug, Default)]
+pub struct Algorithm(pub biscuit_auth::Algorithm);
+
+impl ValueEnum for Algorithm {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Self(biscuit_auth::Algorithm::Ed25519),
+            Self(biscuit_auth::Algorithm::Secp256r1),
+        ]
+    }
+
+    fn to_possible_value<'a>(&self) -> Option<clap::PossibleValue<'a>> {
+        Some(PossibleValue::new(match self.0 {
+            biscuit_auth::Algorithm::Ed25519 => "ed25519",
+            biscuit_auth::Algorithm::Secp256r1 => "secp256r1",
+        }))
+    }
+}
+
+impl Display for Algorithm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 // `Base64String` is never constructed, but is still handled in
@@ -47,6 +80,7 @@ pub enum KeyBytes {
     FromStdin(KeyFormat),
     FromFile(KeyFormat, PathBuf),
     HexString(String),
+    PemString(String),
 }
 
 pub enum DatalogInput {
@@ -275,36 +309,66 @@ fn read_authorizer_from_snapshot(
     Ok(builder)
 }
 
+fn read_pem_private_key(str: &str, alg: &Option<Algorithm>) -> Result<PrivateKey> {
+    Ok(match alg {
+        Some(alg) => PrivateKey::from_pem_with_algorithm(str, alg.0),
+        None => PrivateKey::from_pem(str),
+    }?)
+}
+
 pub fn read_private_key_from(from: &KeyBytes, alg: &Option<Algorithm>) -> Result<PrivateKey> {
-    let key = match from {
-        KeyBytes::FromStdin(KeyFormat::RawBytes) => {
+    let key = match (from, alg) {
+        (KeyBytes::FromStdin(KeyFormat::Raw), Some(alg)) => {
             let bytes = read_stdin_bytes()?;
-            PrivateKey::from_bytes(&bytes, alg.unwrap_or_default())
+            PrivateKey::from_bytes(&bytes, alg.0)
                 .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromStdin(KeyFormat::HexKey) => {
+        (KeyBytes::FromStdin(KeyFormat::Hex), None) => {
             let str = read_stdin_string("hex-encoded private key")?;
             str.parse()
                 .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromFile(KeyFormat::RawBytes, path) => {
+        (KeyBytes::FromStdin(KeyFormat::Pem), None) => {
+            let str = read_stdin_string("PEM private key")?;
+            read_pem_private_key(&str, alg)
+                .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
+        }
+        (KeyBytes::FromFile(KeyFormat::Raw, path), Some(alg)) => {
             let bytes = fs::read(path).map_err(|_| FileNotFound(path.clone()))?;
-            PrivateKey::from_bytes(&bytes, alg.unwrap_or_default())
+            PrivateKey::from_bytes(&bytes, alg.0)
                 .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromFile(KeyFormat::HexKey, path) => {
+        (KeyBytes::FromFile(KeyFormat::Hex, path), None) => {
+            let str = fs::read_to_string(path).map_err(|e| match e.kind() {
+                io::ErrorKind::NotFound => FileNotFound(path.clone()),
+                _ => FileError(e),
+            })?;
+            str.trim()
+                .parse()
+                .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
+        }
+        (KeyBytes::FromFile(KeyFormat::Pem, path), None) => {
             let str = fs::read_to_string(path).map_err(|_| FileNotFound(path.clone()))?;
-            str.parse()
+            read_pem_private_key(&str, alg)
                 .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::HexString(str) => str
+        (KeyBytes::HexString(str), None) => str
             .parse()
             .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?,
+        (KeyBytes::PemString(str), None) => read_pem_private_key(str, alg)
+            .map_err(|e| ParseError("private key".to_string(), format!("{}", &e)))?,
+        (KeyBytes::FromStdin(KeyFormat::Raw), None)
+        | (KeyBytes::FromFile(KeyFormat::Raw, _), None) => {
+            bail!("Raw private key binary input requires an explicit key algorithm")
+        }
+        (_, Some(_)) => {
+            bail!("The private key algorithm must only be set when reading raw binary input")
+        }
     };
     let key_alg = key.algorithm().into();
 
     if let Some(a) = alg {
-        if *a != key_alg {
+        if a.0 != key_alg {
             Err(std::io::Error::other(format!(
                 "Inconsistent algorithm: key algorithm is {}, expected algorithm is {}",
                 key_alg, a
@@ -315,36 +379,63 @@ pub fn read_private_key_from(from: &KeyBytes, alg: &Option<Algorithm>) -> Result
     Ok(key)
 }
 
+fn read_pem_public_key(str: &str, alg: &Option<Algorithm>) -> Result<PublicKey> {
+    Ok(match alg {
+        Some(alg) => PublicKey::from_pem_with_algorithm(str, alg.0),
+        None => PublicKey::from_pem(str),
+    }?)
+}
+
 pub fn read_public_key_from(from: &KeyBytes, alg: &Option<Algorithm>) -> Result<PublicKey> {
-    let key = match from {
-        KeyBytes::FromStdin(KeyFormat::RawBytes) => {
+    let key = match (from, alg) {
+        (KeyBytes::FromStdin(KeyFormat::Raw), Some(alg)) => {
             let bytes = read_stdin_bytes()?;
-            PublicKey::from_bytes(&bytes, alg.unwrap_or_default())
+            PublicKey::from_bytes(&bytes, alg.0)
                 .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromStdin(KeyFormat::HexKey) => {
+        (KeyBytes::FromStdin(KeyFormat::Hex), None) => {
             let str = read_stdin_string("hex-encoded public key")?;
             str.parse()
                 .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromFile(KeyFormat::RawBytes, path) => {
+        (KeyBytes::FromStdin(KeyFormat::Pem), None) => {
+            let str = read_stdin_string("PEM public key")?;
+            read_pem_public_key(&str, alg)
+                .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
+        }
+        (KeyBytes::FromFile(KeyFormat::Raw, path), Some(alg)) => {
             let bytes = fs::read(path).map_err(|_| FileNotFound(path.clone()))?;
-            PublicKey::from_bytes(&bytes, alg.unwrap_or_default())
+            PublicKey::from_bytes(&bytes, alg.0)
                 .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::FromFile(KeyFormat::HexKey, path) => {
+        (KeyBytes::FromFile(KeyFormat::Hex, path), None) => {
             let str = fs::read_to_string(path).map_err(|_| FileNotFound(path.clone()))?;
-            str.parse()
+            str.trim()
+                .parse()
                 .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
         }
-        KeyBytes::HexString(str) => str
+        (KeyBytes::FromFile(KeyFormat::Pem, path), None) => {
+            let str = fs::read_to_string(path).map_err(|_| FileNotFound(path.clone()))?;
+            read_pem_public_key(&str, alg)
+                .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?
+        }
+        (KeyBytes::HexString(str), None) => str
             .parse()
             .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?,
+        (KeyBytes::PemString(str), None) => read_pem_public_key(str, alg)
+            .map_err(|e| ParseError("public key".to_string(), format!("{}", &e)))?,
+        (KeyBytes::FromStdin(KeyFormat::Raw), None)
+        | (KeyBytes::FromFile(KeyFormat::Raw, _), None) => {
+            bail!("Raw public key binary input requires an explicit key algorithm")
+        }
+        (_, Some(_)) => {
+            bail!("The public key algorithm must only be set when reading raw binary input")
+        }
     };
     let key_alg = key.algorithm().into();
 
     if let Some(a) = alg {
-        if *a != key_alg {
+        if a.0 != key_alg {
             Err(std::io::Error::other(format!(
                 "Inconsistent algorithm: key algorithm is {}, expected algorithm is {}",
                 key_alg, a


### PR DESCRIPTION
biscuit-auth has optional support for the PEM format. biscuit-cli should expose that

## Changes

- use an explicit option for key format instead of `--raw-xx` switches
- support for private key PEM input and output in `biscuit keypair`
- support for private key PEM input in `biscuit generate` and `biscuit generate-third-party-block`
- support for public key PEM input in `biscuit inspect`
- use `value_enum` for key format and key algorithm (automatic listing of possible values by clap)
- require and only accept `key-algorithm` when reading raw key bytes
- factor out common parameters for private key input in `generate` and `generate-third-party-block`
- support reading sepc256r1 keys in `--param`

<details>
<summary>Examples</summary>

```
❯ biscuit keypair --help
biscuit-keypair
Create and manipulate key pairs

USAGE:
    biscuit keypair [OPTIONS]

OPTIONS:
        --from-algorithm <PRIVATE_KEY_ALGORITHM>
            Specify the private key algorithm, only when reading the private key raw bytes [possible
            values: ed25519, secp256r1]

        --from-file <PRIVATE_KEY_FILE>
            Generate the keypair from a private key stored in the given file (or use `-` to read it
            from stdin). If omitted, a random keypair will be generated

        --from-format <PRIVATE_KEY_FORMAT>
            Input format for the private key (when provided) [default: hex] [possible values: raw,
            hex, pem]

        --from-private-key <PRIVATE_KEY>
            Generate the keypair from the given private key. If omitted, a random keypair will be
            generated

    -h, --help
            Print help information

        --key-algorithm <KEYPAIR_ALGORITHM>
            Key algorithm used when generating a keypair [default: ed25519] [possible values:
            ed25519, secp256r1]

        --key-output-format <KEY_OUTPUT_FORMAT>
            Public and private key output format [default: hex] [possible values: raw, hex, pem]

        --only-private-key
            Only output the public key

        --only-public-key
            Only output the private key

❯ biscuit keypair --output-key-format pem --key-algorithm secp256r1
Generating a new random keypair
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8mCCBbCvAq+SvitD
OpTK69wEGR6GrxBZKRrQqtarTfuhRANCAAQn6uGCQYMNtz/kV7OoQMTHyBhdT3l0
lZTMJQw5wJRL36sxUipNpU/kqmPzvgaKd28DvK1aIoYhIf5yS/+BAovP
-----END PRIVATE KEY-----
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ+rhgkGDDbc/5FezqEDEx8gYXU95
dJWUzCUMOcCUS9+rMVIqTaVP5Kpj874GindvA7ytWiKGISH+ckv/gQKLzw==
-----END PUBLIC KEY-----
```

```
❯ biscuit keypair --from-file - --from-format pem --key-output-format pem
Please input a PEM private key, followed by <enter> and ^D
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8mCCBbCvAq+SvitD
OpTK69wEGR6GrxBZKRrQqtarTfuhRANCAAQn6uGCQYMNtz/kV7OoQMTHyBhdT3l0
lZTMJQw5wJRL36sxUipNpU/kqmPzvgaKd28DvK1aIoYhIf5yS/+BAovP
-----END PRIVATE KEY-----
Generating a keypair from the provided private key
-----BEGIN PRIVATE KEY-----
MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8mCCBbCvAq+SvitD
OpTK69wEGR6GrxBZKRrQqtarTfuhRANCAAQn6uGCQYMNtz/kV7OoQMTHyBhdT3l0
lZTMJQw5wJRL36sxUipNpU/kqmPzvgaKd28DvK1aIoYhIf5yS/+BAovP
-----END PRIVATE KEY-----
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ+rhgkGDDbc/5FezqEDEx8gYXU95
dJWUzCUMOcCUS9+rMVIqTaVP5Kpj874GindvA7ytWiKGISH+ckv/gQKLzw==
-----END PUBLIC KEY-----
```

</details>

## TODO

- [x] handle format in `keypair`
- [x] make sure `unreachable!()` calls are still impossible to reach
- [x] handle format in `inspect`, `attenuate`, `generate`
- [x] fix clap comments / names