### PR TITLE
Configure Dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"


### PR DESCRIPTION
I was trying to build a pre-release version in a fork and I noticed deprecation warnings from actions dependencies.

I use dependabot on my repos for this, as in [Keeping your actions up to date with Dependabot - GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).
I figured it was quick enough to make the PR.
(The actions run as though forked, so you maintainers may need to approve failed runs.)